### PR TITLE
🐛  Fixed bug that did not allow to pass aliased modules as value for option `:using`

### DIFF
--- a/lib/maru/entity.ex
+++ b/lib/maru/entity.ex
@@ -191,7 +191,7 @@ defmodule Maru.Entity do
     Enum.reduce(pipeline, accumulator, &(do_parse(&1, &2, caller)))
   end
 
-  defp do_parse(:attr_name, %{options: options, runtime: runtime, information: information}, caller) do
+  defp do_parse(:attr_name, %{options: options, runtime: runtime, information: information}, _caller) do
     group     = options |> Keyword.fetch!(:group)
     attr_name = options |> Keyword.fetch!(:attr_name)
     param_key = options |> Keyword.get(:source, attr_name)
@@ -206,7 +206,7 @@ defmodule Maru.Entity do
     }
   end
 
-  defp do_parse(:if_func, %{options: options, runtime: runtime, information: information}, caller) do
+  defp do_parse(:if_func, %{options: options, runtime: runtime, information: information}, _caller) do
     if_func     = options |> Keyword.get(:if)
     unless_func = options |> Keyword.get(:unless)
     options     = options |> Keyword.drop([:if, :unless])
@@ -265,7 +265,7 @@ defmodule Maru.Entity do
      }
   end
 
-  defp do_parse(:do_func, %{options: options, runtime: runtime, information: information}, caller) do
+  defp do_parse(:do_func, %{options: options, runtime: runtime, information: information}, _caller) do
     do_func    = options |> Keyword.get(:do_func)
     param_key  = options |> Keyword.fetch!(:param_key)
     batch      = Keyword.get(options, :batch)
@@ -303,7 +303,7 @@ defmodule Maru.Entity do
     }
   end
 
-  defp do_parse(:build_struct, %{runtime: runtime, information: information}, caller) do
+  defp do_parse(:build_struct, %{runtime: runtime, information: information}, _caller) do
     %Exposure{runtime: runtime, information: information}
   end
 

--- a/test/maru/entity_test.exs
+++ b/test/maru/entity_test.exs
@@ -67,7 +67,6 @@ defmodule Maru.EntityTest do
       assert PostEntity.serialize([post1, post2]) == expected
     end
 
-    @tag asdf: true
     test "serializes stuff using with" do
       post = %{id: 2, title: "My other title", body: "<b>html body</b>"}
       comment = %{body: "<b>comment body</b>", post: post}

--- a/test/maru/entity_test.exs
+++ b/test/maru/entity_test.exs
@@ -11,12 +11,13 @@ defmodule Maru.EntityTest do
 
   defmodule CommentEntity do
     use Maru.Entity
+    alias Maru.EntityTest.PostEntity
 
     expose :body
     expose :nested do
       expose :rename, source: :body
     end
-    expose :post, using: Maru.EntityTest.PostEntity
+    expose :post, using: PostEntity
   end
 
   defmodule IfCommentEntity do
@@ -66,6 +67,7 @@ defmodule Maru.EntityTest do
       assert PostEntity.serialize([post1, post2]) == expected
     end
 
+    @tag asdf: true
     test "serializes stuff using with" do
       post = %{id: 2, title: "My other title", body: "<b>html body</b>"}
       comment = %{body: "<b>comment body</b>", post: post}


### PR DESCRIPTION
Solves issue https://github.com/elixir-maru/maru_entity/issues/10.

Followed instructions in [`Macro` docs](https://hexdocs.pm/elixir/Macro.html#expand_once/2-examples) on how to expand an AST corresponding to an aliased module.

The solution is to pass the whole quoted expression or AST for `SomeAliasedModule` to `Macro.expand(ast, env)`, where `env` should be the module where the alias was declarated, normally `__CALLER__`. In order to have access to the caller, I had to modify `do_parse` and  `parse` to receive the caller as an argument.