### PR TITLE
✨  Allow any expression as a value for \´:if\´ option in \´expose/n\´…

### DIFF
--- a/lib/maru/entity.ex
+++ b/lib/maru/entity.ex
@@ -275,7 +275,7 @@ defmodule Maru.Entity do
         {nil, nil} -> quote do
             fn(_, _) -> true end
           end
-        {nil, {:fn, _, _}=f} ->
+        {nil, f} ->
           quote do
             fn(instance, options) ->
               case unquote(f).(instance, options) do
@@ -284,7 +284,7 @@ defmodule Maru.Entity do
               end
             end
           end
-        {{:fn, _, _}=f, nil} ->
+        {f, nil} ->
           quote do
             fn(instance, options) ->
               case unquote(f).(instance, options) do

--- a/test/maru/entity_test.exs
+++ b/test/maru/entity_test.exs
@@ -23,7 +23,9 @@ defmodule Maru.EntityTest do
     use Maru.Entity
 
     expose :body
-    expose :post, using: Maru.EntityTest.PostEntity, if: fn comment, _options -> comment.post != nil end
+    expose :post, using: Maru.EntityTest.PostEntity, if: &should_expose_post?/2
+
+    defp should_expose_post?(comment, _options), do: comment.post != nil
   end
 
   defmodule UnlessCommentEntity do


### PR DESCRIPTION
Fixes https://github.com/elixir-maru/maru_entity/issues/16.

Did minimal changes to allow any expression as a value for `:if` option in `expose :some_attr, if: some_fn`.
This way you can pass variables, captured functions or whatever your heart desires.