### PR TITLE
Fix compilation warning (IEx 1.14.3)

### DIFF
--- a/lib/maru/entity/runtime.ex
+++ b/lib/maru/entity/runtime.ex
@@ -373,7 +373,7 @@ defmodule Maru.Entity.Runtime do
     :ets.insert(state.data, {id, result, idx})
     :ok
   rescue
-    e -> exit({:error, e, System.stacktrace()})
+    e -> exit({:error, e, __STACKTRACE__})
   end
 
   @spec do_serialize(


### PR DESCRIPTION
```
⨯ iex -v
IEx 1.14.3 (compiled with Erlang/OTP 25)

⨯ mix compile
warning: System.stacktrace/0 is deprecated. Use __STACKTRACE__ instead
  lib/maru/entity/runtime.ex:376: Maru.Entity.Runtime.do_serialize/2
```