### PR TITLE
Fix Elixir 1.17 warnings

### DIFF
--- a/lib/maru/entity/runtime.ex
+++ b/lib/maru/entity/runtime.ex
@@ -336,7 +336,7 @@ defmodule Maru.Entity.Runtime do
               fn _ -> true end
             )
 
-          exposures = Enum.filter(serializer.module.__exposures__, exposure_filter_func)
+          exposures = Enum.filter(serializer.module.__exposures__(), exposure_filter_func)
 
           do_serialize(
             exposures,
@@ -355,7 +355,7 @@ defmodule Maru.Entity.Runtime do
             )
 
           exposures =
-            serializer.module.__exposures__
+            serializer.module.__exposures__()
             |> Enum.filter(exposure_filter_func)
             |> Enum.filter(fn exposure ->
               exposure.attr_group in Enum.map(attrs, &List.wrap/1)


### PR DESCRIPTION
Resolves the following warnings that arise in Elixir 1.17

```
warning: using map.field notation (without parentheses) to invoke function Maru.EntityTest.ReturnOnlyWantedFieldsWithBeforeSerializeTest.__exposures__() is deprecated, you must add parentheses instead: remote.function()
  (maru_entity 0.2.3) lib/maru/entity/runtime.ex:358: Maru.Entity.Runtime.do_serialize/2
```